### PR TITLE
Add (finish-output stream) at the end of write-response! to force buffer flush.

### DIFF
--- a/src/response.lisp
+++ b/src/response.lisp
@@ -35,6 +35,7 @@
     #-windows(crlf stream)
     #+windows(format stream "~%")
     (write-ln stream it))
+  (finish-output stream)
   (values))
 
 ;;;;;;;;;; HTTP basic responses


### PR DESCRIPTION
Buffer behavior can be different on osx/bsd (line buffered) vs *nix (fully buffered) which means on *nix the buffers were not flushing before the socket was closed, resulting in a connection reset / no data error.